### PR TITLE
fix: match audio and video extensions case-insensitively

### DIFF
--- a/fish_audio_preprocess/cli/merge_lab.py
+++ b/fish_audio_preprocess/cli/merge_lab.py
@@ -24,7 +24,9 @@ def merge_lab(
     recursive: bool,
 ):
     audio_files = list_files(input_dir, recursive=recursive)
-    audio_files = [str(file) for file in audio_files if file.suffix in AUDIO_EXTENSIONS]
+    audio_files = [
+        str(file) for file in audio_files if file.suffix.lower() in AUDIO_EXTENSIONS
+    ]
     results = []
     for audio_file in tqdm(audio_files):
         # logger.info(f"Processing {audio_file}")

--- a/fish_audio_preprocess/cli/transcribe.py
+++ b/fish_audio_preprocess/cli/transcribe.py
@@ -95,7 +95,9 @@ def transcribe(
     logger.info(f"Transcribing audio files in {input_dir}")
     # 扫描出所有的音频文件
     audio_files = list_files(input_dir, recursive=recursive)
-    audio_files = [str(file) for file in audio_files if file.suffix in AUDIO_EXTENSIONS]
+    audio_files = [
+        str(file) for file in audio_files if file.suffix.lower() in AUDIO_EXTENSIONS
+    ]
 
     if len(audio_files) == 0:
         logger.error(f"No audio files found in {input_dir}.")

--- a/fish_audio_preprocess/utils/file.py
+++ b/fish_audio_preprocess/utils/file.py
@@ -72,7 +72,11 @@ def list_files(
     )
 
     if extensions is not None:
-        files = [f for f in files if f.suffix in extensions]
+        # Match case-insensitively. Recorders, cameras and phones routinely
+        # write .WAV/.MP3/.MP4, and Path.suffix preserves that case, so an
+        # exact match silently skipped those files.
+        extensions = {ext.lower() for ext in extensions}
+        files = [f for f in files if f.suffix.lower() in extensions]
 
     if sort:
         files = sorted(files)


### PR DESCRIPTION
## Problem

`list_files()` filters by extension with an exact match:

```python
files = [f for f in files if f.suffix in extensions]
```

`Path.suffix` preserves case, and `AUDIO_EXTENSIONS` and `VIDEO_EXTENSIONS` are all lowercase. A file named `RECORDING.WAV` therefore never matches, and `list_files` drops it without a warning.

Recorders, field recorders, phones and camera firmware routinely write uppercase extensions, so this hits real datasets. Every command that scans a directory is affected, because they all pass those lowercase sets: `length`, `loudness-norm`, `merge-short`, `resample`, `separate-audio`, `slice-audio`, `convert-to-wav`, `merge-lab` and `transcribe`.

The failure is silent. The files are simply absent from the count, so a run over a directory of `.WAV` files reports success having processed nothing.

Reproduced against `main` with six files in one directory:

```
files on disk : ['Mixed.Wav', 'UPPER.MP3', 'UPPER.WAV', 'ignored.txt', 'lower.mp3', 'lower.wav']
list_files got: ['lower.mp3', 'lower.wav']

MISSING (silently skipped): ['Mixed.Wav', 'UPPER.MP3', 'UPPER.WAV']
```

After the change all five audio files are found and `ignored.txt` is still excluded.

## Fix

Compare case-insensitively. `list_files` also lowercases the incoming set, so a caller passing `{".WAV"}` behaves the same way.

`cli/merge_lab.py` and `cli/transcribe.py` re-filter on `AUDIO_EXTENSIONS` after calling `list_files`, so they carried the same comparison and are updated too.

## Notes

Only the extension comparison changed. Sorting, recursion, the video/audio sets and the returned `Path` objects keep their existing behaviour, and the original case of each filename is untouched.

The repository has no test suite or test dependency, so rather than introduce one I verified with the directory reproduction above, run before and after the change. Happy to add tests if you would like a framework brought in.

`black --check`, `isort --check-only` and `codespell` are all clean.
